### PR TITLE
chore(github): rebrand fork's workflows and templates for johnford2002

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 # These are supported funding model platforms
 
-buy_me_a_coffee: mbassem
-github: MohamedBassem
+github: johnford2002

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Have you searched for an existing open/closed issue?
       description: |
-        To help us keep these issues under control, please ensure you have first [searched our issue list](https://github.com/karakeep-app/karakeep/issues?q=is%3Aissue) for any existing issues that cover the fundamental benefit/goal of your request.
+        To help us keep these issues under control, please ensure you have first [searched our issue list](https://github.com/johnford2002/karakeep/issues?q=is%3Aissue) for any existing issues that cover the fundamental benefit/goal of your request.
       options:
         - label: I have searched for existing issues and none cover my fundamental request
           required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -5,4 +5,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        We use Github discussions for anything that's not a bug report or a feature request. Please ask your question in the [Q&A section](https://github.com/karakeep-app/karakeep/discussions/categories/q-a) and someone will answer it soon!
+        We use Github discussions for anything that's not a bug report or a feature request. Please ask your question in the [Q&A section](https://github.com/johnford2002/karakeep/discussions/categories/q-a) and someone will answer it soon!

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,9 +1,8 @@
 name: Android App Release Build
-
+# Disabled in this fork. The upstream workflow publishes a karakeep-branded build.
+# Trigger manually via workflow_dispatch if you intend to produce your own build.
 on:
-  push:
-    tags:
-      - 'android/v[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude:
     if: |
-      github.actor == 'MohamedBassem' && (
+      github.actor == 'johnford2002' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,8 +1,7 @@
 name: Publish CLI Package to npm
+# Disabled in this fork to avoid conflicting with upstream @karakeep/cli on npm.
+# Trigger manually via workflow_dispatch if you publish your own package.
 on:
-  push:
-    tags:
-      - "cli/v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,28 +24,28 @@ jobs:
           - image: web
             name: karakeep-web
             target: web
-            tags_latest: ghcr.io/hoarder-app/hoarder-web:latest,ghcr.io/mohamedbassem/hoarder-web:latest,ghcr.io/karakeep-app/karakeep-web:latest
-            tags_release: ghcr.io/hoarder-app/hoarder-web:${{ github.event.release.name }},ghcr.io/mohamedbassem/hoarder-web:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-web:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder-web:release,ghcr.io/mohamedbassem/hoarder-web:release,ghcr.io/karakeep-app/karakeep-web:release
+            tags_latest: ghcr.io/johnford2002/karakeep-web:latest
+            tags_release: ghcr.io/johnford2002/karakeep-web:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-web:release
           - image: workers
             name: karakeep-workers
             target: workers
-            tags_latest: ghcr.io/hoarder-app/hoarder-workers:latest,ghcr.io/mohamedbassem/hoarder-workers:latest,ghcr.io/karakeep-app/karakeep-workers:latest
-            tags_release: ghcr.io/hoarder-app/hoarder-workers:${{ github.event.release.name }},ghcr.io/mohamedbassem/hoarder-workers:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-workers:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder-workers:release,ghcr.io/mohamedbassem/hoarder-workers:release,ghcr.io/karakeep-app/karakeep-workers:release
+            tags_latest: ghcr.io/johnford2002/karakeep-workers:latest
+            tags_release: ghcr.io/johnford2002/karakeep-workers:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-workers:release
           - image: cli
             name: karakeep-cli
             target: cli
-            tags_latest: ghcr.io/hoarder-app/hoarder-cli:latest,ghcr.io/mohamedbassem/hoarder-cli:latest,ghcr.io/karakeep-app/karakeep-cli:latest
-            tags_release: ghcr.io/hoarder-app/hoarder-cli:${{ github.event.release.name }},ghcr.io/mohamedbassem/hoarder-cli:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-cli:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder-cli:release,ghcr.io/mohamedbassem/hoarder-cli:release,ghcr.io/karakeep-app/karakeep-cli:release
+            tags_latest: ghcr.io/johnford2002/karakeep-cli:latest
+            tags_release: ghcr.io/johnford2002/karakeep-cli:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-cli:release
           - image: mcp
             name: karakeep-mcp
             target: mcp
-            tags_latest: ghcr.io/karakeep-app/karakeep-mcp:latest
-            tags_release: ghcr.io/karakeep-app/karakeep-mcp:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-mcp:release
+            tags_latest: ghcr.io/johnford2002/karakeep-mcp:latest
+            tags_release: ghcr.io/johnford2002/karakeep-mcp:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-mcp:release
           - image: aio
             name: karakeep-aio
             target: aio
-            tags_latest: ghcr.io/hoarder-app/hoarder:latest,ghcr.io/karakeep-app/karakeep:latest
-            tags_release: ghcr.io/hoarder-app/hoarder:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder:release,ghcr.io/karakeep-app/karakeep:release
+            tags_latest: ghcr.io/johnford2002/karakeep:latest
+            tags_release: ghcr.io/johnford2002/karakeep:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep:release
     runs-on: ${{ matrix.os }}
     permissions:
       packages: write
@@ -61,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_GITHUB_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare tags
         id: tags
@@ -105,8 +105,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.tags.outputs.all }}
-          cache-from: type=registry,ref=ghcr.io/karakeep-app/karakeep-build-cache:${{ matrix.target }}-${{ matrix.suffix }}
-          cache-to: type=registry,mode=max,ref=ghcr.io/karakeep-app/karakeep-build-cache:${{ matrix.target }}-${{ matrix.suffix }}
+          cache-from: type=registry,ref=ghcr.io/johnford2002/karakeep-build-cache:${{ matrix.target }}-${{ matrix.suffix }}
+          cache-to: type=registry,mode=max,ref=ghcr.io/johnford2002/karakeep-build-cache:${{ matrix.target }}-${{ matrix.suffix }}
 
   manifest:
     needs: build
@@ -119,20 +119,20 @@ jobs:
       matrix:
         include:
           - name: karakeep-web
-            tags_latest: ghcr.io/hoarder-app/hoarder-web:latest,ghcr.io/mohamedbassem/hoarder-web:latest,ghcr.io/karakeep-app/karakeep-web:latest
-            tags_release: ghcr.io/hoarder-app/hoarder-web:${{ github.event.release.name }},ghcr.io/mohamedbassem/hoarder-web:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-web:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder-web:release,ghcr.io/mohamedbassem/hoarder-web:release,ghcr.io/karakeep-app/karakeep-web:release
+            tags_latest: ghcr.io/johnford2002/karakeep-web:latest
+            tags_release: ghcr.io/johnford2002/karakeep-web:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-web:release
           - name: karakeep-workers
-            tags_latest: ghcr.io/hoarder-app/hoarder-workers:latest,ghcr.io/mohamedbassem/hoarder-workers:latest,ghcr.io/karakeep-app/karakeep-workers:latest
-            tags_release: ghcr.io/hoarder-app/hoarder-workers:${{ github.event.release.name }},ghcr.io/mohamedbassem/hoarder-workers:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-workers:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder-workers:release,ghcr.io/mohamedbassem/hoarder-workers:release,ghcr.io/karakeep-app/karakeep-workers:release
+            tags_latest: ghcr.io/johnford2002/karakeep-workers:latest
+            tags_release: ghcr.io/johnford2002/karakeep-workers:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-workers:release
           - name: karakeep-cli
-            tags_latest: ghcr.io/hoarder-app/hoarder-cli:latest,ghcr.io/mohamedbassem/hoarder-cli:latest,ghcr.io/karakeep-app/karakeep-cli:latest
-            tags_release: ghcr.io/hoarder-app/hoarder-cli:${{ github.event.release.name }},ghcr.io/mohamedbassem/hoarder-cli:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-cli:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder-cli:release,ghcr.io/mohamedbassem/hoarder-cli:release,ghcr.io/karakeep-app/karakeep-cli:release
+            tags_latest: ghcr.io/johnford2002/karakeep-cli:latest
+            tags_release: ghcr.io/johnford2002/karakeep-cli:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-cli:release
           - name: karakeep-mcp
-            tags_latest: ghcr.io/karakeep-app/karakeep-mcp:latest
-            tags_release: ghcr.io/karakeep-app/karakeep-mcp:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep-mcp:release
+            tags_latest: ghcr.io/johnford2002/karakeep-mcp:latest
+            tags_release: ghcr.io/johnford2002/karakeep-mcp:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep-mcp:release
           - name: karakeep-aio
-            tags_latest: ghcr.io/hoarder-app/hoarder:latest,ghcr.io/karakeep-app/karakeep:latest
-            tags_release: ghcr.io/hoarder-app/hoarder:${{ github.event.release.name }},ghcr.io/karakeep-app/karakeep:${{ github.event.release.name }},ghcr.io/hoarder-app/hoarder:release,ghcr.io/karakeep-app/karakeep:release
+            tags_latest: ghcr.io/johnford2002/karakeep:latest
+            tags_release: ghcr.io/johnford2002/karakeep:${{ github.event.release.name }},ghcr.io/johnford2002/karakeep:release
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -142,7 +142,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_GITHUB_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifests for ${{ matrix.name }}
         env:

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -1,9 +1,8 @@
 name: Extension Release Build
-
+# Disabled in this fork. The upstream workflow publishes a karakeep-branded build.
+# Trigger manually via workflow_dispatch if you intend to produce your own build.
 on:
-  push:
-    tags:
-      - 'extension/v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,9 +1,8 @@
 name: iOS App Release Build
-
+# Disabled in this fork. The upstream workflow publishes a karakeep-branded build.
+# Trigger manually via workflow_dispatch if you intend to produce your own build.
 on:
-  push:
-    tags:
-      - 'ios/v[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -1,9 +1,8 @@
 name: Publish MCP Package to npm
+# Disabled in this fork to avoid conflicting with the upstream MCP package on npm.
+# Trigger manually via workflow_dispatch if you publish your own package.
 on:
-  push:
-    tags:
-      # This is a glob pattern not a regex
-      - "mcp/v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   id-token: write # Required for OIDC

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,9 +1,8 @@
-name: Publish CLI Package to npm
+name: Publish SDK Package to npm
+# Disabled in this fork to avoid conflicting with the upstream SDK package on npm.
+# Trigger manually via workflow_dispatch if you publish your own package.
 on:
-  push:
-    tags:
-      # This is a glob pattern not a regex
-      - "sdk/v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   id-token: write # Required for OIDC


### PR DESCRIPTION
## Summary

This is a fork of `karakeep-app/karakeep`. Several files under `.github/` still
referenced upstream identities (`karakeep-app`, `hoarder-app`, `mohamedbassem`,
`MohamedBassem`, `mbassem`) which would either fail in this fork (missing
secrets, wrong actor) or actively mis-route users back to the upstream repo.
This PR rebrands them for `johnford2002/karakeep`.

## Workflow changes

**`docker.yml` — repointed and simplified**
- Images now publish only to `johnford2002` on GHCR:
  - `ghcr.io/johnford2002/karakeep` (aio)
  - `ghcr.io/johnford2002/karakeep-web`
  - `ghcr.io/johnford2002/karakeep-workers`
  - `ghcr.io/johnford2002/karakeep-cli`
  - `ghcr.io/johnford2002/karakeep-mcp`
- Build cache moved to `ghcr.io/johnford2002/karakeep-build-cache`
- Removed all upstream tag mirrors (`hoarder-app/*`, `mohamedbassem/*`, `karakeep-app/*`)
- Auth switched from `secrets.GHCR_GITHUB_PAT` → `secrets.GITHUB_TOKEN`. The
  job already has `packages: write`, and the registry/repo owner now match,
  so a custom PAT is no longer needed.

**`claude.yml` — actor gate updated**
- `github.actor == 'MohamedBassem'` → `github.actor == 'johnford2002'` so the
  `@claude` mention trigger works for the fork owner.

**`cli.yml`, `mcp.yml`, `sdk.yml` — npm publish disabled**
- Removed tag-push triggers so a tag like `cli/v1.2.3` here can't try to
  publish to upstream's `@karakeep/cli`, `@karakeep/mcp`, `@karakeep/sdk`
  packages on npm. Kept `workflow_dispatch` so they're still manually
  runnable if you ever ship your own packages.

**`android.yml`, `ios.yml`, `extension.yml` — release builds disabled**
- Removed auto tag-push triggers (these upstream workflows produce
  karakeep-branded mobile/extension artifacts). Kept `workflow_dispatch`.

## Non-workflow changes

**`FUNDING.yml`**
- Removed `buy_me_a_coffee: mbassem` (upstream author's account)
- Repointed `github:` from `MohamedBassem` to `johnford2002`. If no Sponsors
  profile exists for that handle, GitHub silently hides the Sponsor button.

**`.github/ISSUE_TEMPLATE/`**
- `question.yml`: Q&A discussions link → `johnford2002/karakeep`
- `feature_request.yml`: existing-issues search link → `johnford2002/karakeep`
- `bug_report.yml` was left as-is (only references `docs.karakeep.app`,
  which is an upstream-hosted docs site, not a github org reference).

## One-time setup required after merge

The first push to `main` will try to create new packages under
`ghcr.io/johnford2002/*`. By default, GHCR creates them as **private**. Once
they're created you'll likely want to flip each one to public in the
package settings (or leave them private and configure pull auth on the
hosts that will run them).

## Test plan

- [ ] Merge to `main` and confirm the `Build and Push Docker` workflow runs cleanly
- [ ] Confirm `ghcr.io/johnford2002/karakeep:latest` (and the per-component `-web/-workers/-cli/-mcp` tags) appear in your GHCR packages
- [ ] Flip the new packages to public visibility if desired
- [ ] Sanity check that CI (`ci.yml`) still passes — it was not modified
- [ ] (Optional) `@claude` mention on an issue authored by you to confirm the gate change works

🤖 Generated with [Claude Code](https://claude.com/claude-code)